### PR TITLE
Remove globbing when parsing sources and excludes folder

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,7 @@ function check_file() {
 
 function find_cmd() {
     IFS=','
+    set -o noglob
     paths="$1"
     excludes="$2"
     local -n cmd="$3"
@@ -58,7 +59,8 @@ function find_cmd() {
         is_first=0
     done
     cmd+=" \)"
-    
+
+    set +o noglob
     unset IFS
 }
 


### PR DESCRIPTION
Sources and excludes folders can be set with "*" but in that case the
script performs globbing (filename generation). This leads to a wrong
generated find command where there is no "*".
Example:
 - test
    - f1
    - f2
using "./test/*" we will have "./test/f1/" and './test/f2/'. The
currently generated find command will look inside those folders without
excluding them.

Disable globbing when generating the find command to avoid any problems
with regex excludes or sources folders.

Signed-off-by: Luca Miccio <lucmiccio@gmail.com>