### PR TITLE
Only add excludes to find command if it's defined

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,7 +12,7 @@ An action that check code format using `clang-format` tool. Suitable for project
 ## Inputs
 
 ### `sources`
-Sources to check by this action. It can be a single file, regex of a folder or multiple selecteor seprated by comma (`,`).
+Sources to check by this action. It can be a single file, regex of a folder or multiple selectors separated by comma (`,`).
 
 Default: `"**/*"`.  That means all files in this repository.
 
@@ -23,6 +23,11 @@ Example: If your repository contains many files other than C file, you can try w
 or, for all nested folder
 
 `"src/**/*.h,src/**/*.c"`
+
+### `excludes`
+Sources to exclude from this action. It can be a single file, regex of a folder or multiple selectors separated by comma (`,`).
+
+Default: `""`.
 
 ### `style`
 The style for `clang-format`. Possible value are: `LLVM, GNU, Google, Chromium, Microsoft, Mozilla, WebKit`. If your repository has a `.clang-format` file in the root directory then you can use `file` option here.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,9 +44,11 @@ function find_cmd() {
     local -n cmd="$3"
     
     cmd+="find . -type f "
-    for exclude in $excludes; do
-        cmd+="! -wholename \"./$exclude\" "
-    done
+    if [ -n "$excludes" ]; then
+        for exclude in $excludes; do
+            cmd+="! -wholename \"./$exclude\" "
+        done
+    fi
 
     cmd+="\( "
     local is_first=1


### PR DESCRIPTION
If excludes is not set in the yaml, or set to "", then the following error occurs:

/entrypoint.sh: line 44: local: `': not a valid identifier

When excludes is empty, it causes handling of the for loop over its contents to fail. To prevent this, check that the variable is non-empty prior to looping over its contents.

In addition to this fix, document this feature in the readme and fix some typos there.

Fixes #7