### PR TITLE
Add clang-format-21 support and action test workflow

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,0 +1,33 @@
+name: Action Tests
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-action:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - name: Run clang-format action
+      id: clang-format
+      uses: ./
+      with:
+        sources: 'examples/**'
+        excludes: 'examples/file2.c'
+        style: 'LLVM'
+    - name: Verify version output
+      run: |
+        echo "clang-format version: ${{ steps.clang-format.outputs.clang-format-version }}"
+        if [ -z "${{ steps.clang-format.outputs.clang-format-version }}" ]; then
+          echo "Version output should not be empty"
+          exit 1
+        fi

--- a/.github/workflows/entrypoint-test.yml
+++ b/.github/workflows/entrypoint-test.yml
@@ -16,7 +16,7 @@ jobs:
   test-entrypoint:
     runs-on: ubuntu-latest
     container:
-      image: silkeh/clang:20
+      image: silkeh/clang:21
     steps:
     - uses: actions/checkout@v5
     - name: Basic command works

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM silkeh/clang:20
+FROM silkeh/clang:21
 
 LABEL maintainer="RafikFarhad<rafikfarhad@gmail.com>"
 


### PR DESCRIPTION
## Summary
- Update to clang-format version 21 (Dockerfile and entrypoint-test.yml)
- Add new `action-test.yml` workflow that tests the action using `uses: ./`
- Verifies `clang-format-version` output is populated

For release v6.0.1.

## Test plan
- [x] Entrypoint Tests workflow passes
- [x] Action Tests workflow passes
- [x] `clang-format-version` output is verified in action test

Disclaimer: LLM involved. No robots were harmed in the making of this commit.