### PR TITLE
Add clang-format-22 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM silkeh/clang:22
+# FROM silkeh/clang:22
+FROM ghcr.io/rafikfarhad/clang:22
 
 LABEL maintainer="RafikFarhad<rafikfarhad@gmail.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM silkeh/clang:21
+FROM silkeh/clang:22
 
 LABEL maintainer="RafikFarhad<rafikfarhad@gmail.com>"
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -69,11 +69,12 @@ It will check for code formatting violations on every `push` to GitHub.
 
 ## Version
 
-The latest version of this action uses `clang-format` version 21.
+The latest version of this action uses `clang-format` version 22.
 Use older versions for specific `clang-format` versions.
 
 | Clang Version | Action |
 |---------|---------------|
+| 22 | RafikFarhad/clang-format-github-action@v7 |
 | 21 | RafikFarhad/clang-format-github-action@v6 |
 | 20 | RafikFarhad/clang-format-github-action@v5.1 |
 | 19 | RafikFarhad/clang-format-github-action@v5 |


### PR DESCRIPTION
Closes #20

## Summary

- Bumps `Dockerfile` base image from `silkeh/clang:21` to `ghcr.io/rafikfarhad/clang:22` (using custom image while upstream is pending)
- Updates `ReadMe.md` to reflect version 22 as the latest, adds `@v7` row to the version table

## Docker Base Image

`silkeh/clang:22` is not yet available on Docker Hub as our upstream PR is still waiting (silkeh/docker-clang#32). In the meantime, we are using our own docker image (`ghcr.io/rafikfarhad/clang:22`).

## Test plan

- [x] Use `ghcr.io/rafikfarhad/clang:22` image while upstream silkeh PR is waiting
- [x] Verify CI passes (action-test and entrypoint-test workflows)
- [x] Tag `v7` after merging

Disclaimer: Assisted by machines